### PR TITLE
Feature: Instant Model Loading

### DIFF
--- a/nataili/__init__.py
+++ b/nataili/__init__.py
@@ -6,4 +6,3 @@ enable_local_ray_temp = Switch()
 disable_progress = Switch()
 disable_download_progress = Switch()
 enable_ray_alternative = Switch()
-

--- a/nataili/__init__.py
+++ b/nataili/__init__.py
@@ -5,3 +5,5 @@ disable_voodoo = Switch()
 enable_local_ray_temp = Switch()
 disable_progress = Switch()
 disable_download_progress = Switch()
+enable_ray_alternative = Switch()
+

--- a/nataili/model_manager/compvis.py
+++ b/nataili/model_manager/compvis.py
@@ -178,13 +178,14 @@ class CompVisModelManager(BaseModelManager):
         logger.debug(f"Loading model {model_name} on {device}")
         logger.debug(f"Model path: {ckpt_path}")
 
-        # Disk Cached?
-        cachefile = f"{ckpt_path}.cache"
-        if os.path.exists(cachefile):
-            model = cachefile
+        if voodoo:
+            cachefile = f"{ckpt_path}.cache"
+            if os.path.exists(cachefile):
+                model = cachefile
         else:
             model = self.load_model_from_config(model_path=ckpt_path, config_path=config_path)
             model = model.half() if half_precision else model
+
         if voodoo:
             logger.debug(f"Doing voodoo on {model_name}")
             model = push_model_to_plasma(model, ckpt_path) if isinstance(model, torch.nn.Module) else model

--- a/nataili/model_manager/compvis.py
+++ b/nataili/model_manager/compvis.py
@@ -28,6 +28,7 @@ from torch import nn
 
 import ldm.modules.encoders.modules
 from ldm.util import instantiate_from_config
+from nataili import enable_ray_alternative
 from nataili.cache import get_cache_directory
 from nataili.model_manager.base import BaseModelManager
 from nataili.util.logger import logger
@@ -178,7 +179,7 @@ class CompVisModelManager(BaseModelManager):
         logger.debug(f"Loading model {model_name} on {device}")
         logger.debug(f"Model path: {ckpt_path}")
 
-        if voodoo and get_model_cache_filename(ckpt_path):
+        if voodoo and enable_ray_alternative.active and get_model_cache_filename(ckpt_path):
             model = get_model_cache_filename(ckpt_path)
         else:
             model = self.load_model_from_config(model_path=ckpt_path, config_path=config_path)

--- a/nataili/model_manager/compvis.py
+++ b/nataili/model_manager/compvis.py
@@ -31,7 +31,7 @@ from ldm.util import instantiate_from_config
 from nataili.cache import get_cache_directory
 from nataili.model_manager.base import BaseModelManager
 from nataili.util.logger import logger
-from nataili.util.voodoo import push_model_to_plasma
+from nataili.util.voodoo import push_model_to_plasma, get_model_cache_filename
 
 
 class CompVisModelManager(BaseModelManager):
@@ -178,10 +178,8 @@ class CompVisModelManager(BaseModelManager):
         logger.debug(f"Loading model {model_name} on {device}")
         logger.debug(f"Model path: {ckpt_path}")
 
-        if voodoo:
-            cachefile = f"{ckpt_path}.cache"
-            if os.path.exists(cachefile):
-                model = cachefile
+        if voodoo and get_model_cache_filename(ckpt_path):
+            model = get_model_cache_filename(ckpt_path)
         else:
             model = self.load_model_from_config(model_path=ckpt_path, config_path=config_path)
             model = model.half() if half_precision else model

--- a/nataili/model_manager/compvis.py
+++ b/nataili/model_manager/compvis.py
@@ -32,7 +32,7 @@ from nataili import enable_ray_alternative
 from nataili.cache import get_cache_directory
 from nataili.model_manager.base import BaseModelManager
 from nataili.util.logger import logger
-from nataili.util.voodoo import push_model_to_plasma, get_model_cache_filename
+from nataili.util.voodoo import push_model_to_plasma, get_model_cache_filename, have_model_cache
 
 
 class CompVisModelManager(BaseModelManager):
@@ -179,7 +179,7 @@ class CompVisModelManager(BaseModelManager):
         logger.debug(f"Loading model {model_name} on {device}")
         logger.debug(f"Model path: {ckpt_path}")
 
-        if voodoo and enable_ray_alternative.active and get_model_cache_filename(ckpt_path):
+        if voodoo and enable_ray_alternative.active and have_model_cache(ckpt_path):
             model = get_model_cache_filename(ckpt_path)
         else:
             model = self.load_model_from_config(model_path=ckpt_path, config_path=config_path)

--- a/nataili/model_manager/compvis.py
+++ b/nataili/model_manager/compvis.py
@@ -32,7 +32,7 @@ from nataili import enable_ray_alternative
 from nataili.cache import get_cache_directory
 from nataili.model_manager.base import BaseModelManager
 from nataili.util.logger import logger
-from nataili.util.voodoo import push_model_to_plasma, get_model_cache_filename, have_model_cache
+from nataili.util.voodoo import get_model_cache_filename, have_model_cache, push_model_to_plasma
 
 
 class CompVisModelManager(BaseModelManager):

--- a/nataili/model_manager/compvis.py
+++ b/nataili/model_manager/compvis.py
@@ -18,7 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import sys
 import time
-import pickle
 from pathlib import Path
 
 import open_clip

--- a/nataili/util/voodoo.py
+++ b/nataili/util/voodoo.py
@@ -87,6 +87,10 @@ def get_model_cache_filename(model_filename):
     return os.path.join(DISK_CACHE_DIR, os.path.basename(model_filename)) + ".cache"
 
 
+def have_model_cache(model_filename):
+    return os.path.exists(get_model_cache_filename(model_filename))
+
+
 @contextlib.contextmanager
 def load_from_plasma(ref, device="cuda"):
     if not enable_ray_alternative.active:

--- a/nataili/util/voodoo.py
+++ b/nataili/util/voodoo.py
@@ -119,7 +119,7 @@ def push_model_to_plasma(model: torch.nn.Module, filename=None) -> ray.ObjectRef
             return cachefile
         # Create cache directory if it doesn't already exist
         if not os.path.isdir(MODEL_CACHE_DIR):
-            os.makedirs(ray_temp_dir, exist_ok=True)
+            os.makedirs(MODEL_CACHE_DIR, exist_ok=True)
         # Serialise our object
         with open(cachefile, "wb") as cache:
             pickle.dump(extract_tensors(model), cache, protocol=pickle.HIGHEST_PROTOCOL)

--- a/nataili/util/voodoo.py
+++ b/nataili/util/voodoo.py
@@ -34,7 +34,7 @@ from nataili.util.logger import logger
 warnings.filterwarnings("ignore")
 
 
-DISK_CACHE_DIR = os.path.join(os.path.abspath(os.environ.get("RAY_TEMP_DIR", "./ray")), "model-cache")
+MODEL_CACHE_DIR = os.path.join(os.path.abspath(os.environ.get("RAY_TEMP_DIR", "./ray")), "model-cache")
 
 
 if enable_local_ray_temp.active:
@@ -84,7 +84,7 @@ def replace_tensors(m: torch.nn.Module, tensors: List[Dict], device="cuda"):
 
 
 def get_model_cache_filename(model_filename):
-    return os.path.join(DISK_CACHE_DIR, os.path.basename(model_filename)) + ".cache"
+    return os.path.join(MODEL_CACHE_DIR, os.path.basename(model_filename)) + ".cache"
 
 
 def have_model_cache(model_filename):
@@ -117,6 +117,9 @@ def push_model_to_plasma(model: torch.nn.Module, filename=None) -> ray.ObjectRef
         if os.path.exists(cachefile):
             # Don't store if it already exists
             return cachefile
+        # Create cache directory if it doesn't already exist
+        if not os.path.isdir(MODEL_CACHE_DIR):
+            os.makedirs(ray_temp_dir, exist_ok=True)
         # Serialise our object
         with open(cachefile, "wb") as cache:
             pickle.dump(extract_tensors(model), cache, protocol=pickle.HIGHEST_PROTOCOL)

--- a/nataili/util/voodoo.py
+++ b/nataili/util/voodoo.py
@@ -34,11 +34,9 @@ warnings.filterwarnings("ignore")
 
 if enable_local_ray_temp.active:
     ray_temp_dir = os.path.abspath("./ray")
-    # Don't remove old store if we're using ray alternative
-    if not enable_ray_alternative.active:
-        shutil.rmtree(ray_temp_dir, ignore_errors=True)
-        os.makedirs(ray_temp_dir, exist_ok=True)
-        ray.init(_temp_dir=ray_temp_dir)
+    shutil.rmtree(ray_temp_dir, ignore_errors=True)
+    os.makedirs(ray_temp_dir, exist_ok=True)
+    ray.init(_temp_dir=ray_temp_dir)
     logger.init(f"Ray temp dir '{ray_temp_dir}'", status="Prepared")
 else:
     logger.init_warn("Ray temp dir'", status="OS Default")

--- a/nataili/util/voodoo.py
+++ b/nataili/util/voodoo.py
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import contextlib
 import copy
+import glob
 import os
 import shutil
 import warnings
@@ -33,8 +34,10 @@ from nataili.util.logger import logger
 warnings.filterwarnings("ignore")
 
 if enable_local_ray_temp.active:
-    ray_temp_dir = os.path.abspath("./ray")
-    shutil.rmtree(ray_temp_dir, ignore_errors=True)
+    ray_temp_dir = os.path.abspath(os.environ.get("RAY_TEMP_DIR", "./ray"))
+    session_dirs = glob.glob(os.path.join(ray_temp_dir, "session_*"))
+    for adir in session_dirs:
+        shutil.rmtree(adir, ignore_errors=True)
     os.makedirs(ray_temp_dir, exist_ok=True)
     ray.init(_temp_dir=ray_temp_dir)
     logger.init(f"Ray temp dir '{ray_temp_dir}'", status="Prepared")

--- a/nataili/util/voodoo.py
+++ b/nataili/util/voodoo.py
@@ -19,9 +19,9 @@ import contextlib
 import copy
 import glob
 import os
+import pickle
 import shutil
 import warnings
-import pickle
 from typing import Dict, List, Tuple, TypeVar
 
 import ray
@@ -99,7 +99,7 @@ def load_from_plasma(ref, device="cuda"):
     else:
         # Load object from our persistent store
         with open(ref, "rb") as cache:
-            skeleton, weights = pickle.load(cache)        
+            skeleton, weights = pickle.load(cache)
     replace_tensors(skeleton, weights, device=device)
     skeleton.eval().to(device, memory_format=torch.channels_last)
     yield skeleton
@@ -112,7 +112,7 @@ def push_model_to_plasma(model: torch.nn.Module, filename=None) -> ray.ObjectRef
         ref = ray.put(extract_tensors(model))
     else:
         # Store object directly on disk
-         
+
         cachefile = get_model_cache_filename(filename)
         if os.path.exists(cachefile):
             # Don't store if it already exists


### PR DESCRIPTION
*This is a working proof of concept - it's not complete. In testing, with this code, my worker starts instantly with 150 models once they have been cached.*

For Horde Workers with hundreds of models loaded (using voodoo), starting a worker is **very** slow. Every time the worker starts all models are copied into the ray object store. This object store is wiped every time the worker starts.

If we instead have an option to store loaded models in a persistent disk store (rather than the ephemeral ray object store), we can reduce the worker startup delay to literally zero

Adds: `nataili.enable_ray_alternative` switch. Disabled by default. Enable to enable model caching behaviour.

Implementation idea is simply to not use the ray object store. Instead use pickle directly which makes our "object store" persistent. 

**TODO**
- Discuss
- Detect when model cache needs refreshing due to model updates.
